### PR TITLE
Improve the fix of a possible bug in onvif lib that puts IP:80:554/foo

### DIFF
--- a/src/main/java/org/openhab/binding/ipcamera/handler/IpCameraHandler.java
+++ b/src/main/java/org/openhab/binding/ipcamera/handler/IpCameraHandler.java
@@ -1470,7 +1470,7 @@ public class IpCameraHandler extends BaseThingHandler {
 							"Finished with PTZ with no errors, now fetching the Video URL for RTSP from the camera.");
 					rtspUri = onvifCamera.getMedia().getRTSPStreamUri(profileToken);
 					if (rtspUri.contains(":80:")) {// fixes a possible bug in onvif lib that puts IP:80:554/foo
-						rtspUri.replace(":80:", ":");
+						rtspUri = rtspUri.replace(":80:", ":");
 					}
 
 				} catch (ConnectException e) {


### PR DESCRIPTION
Hello, @Skinah. Thank you for a great binding which opens useful functionality of my cameras using Openhab. I started using HLS stream and faced a bug you thought have fixed. 

Here is a minor fix for issue with IP:80:554/foo. We need to reassign rtspUri as String in Java is immutable and replace method does not change it's value, instead it returns new string.